### PR TITLE
For Dataverse-created maps, link specific users who also have worldmap credentials

### DIFF
--- a/geonode/contrib/datatables/column_helper.py
+++ b/geonode/contrib/datatables/column_helper.py
@@ -1,6 +1,6 @@
 """
 Convenience methods to:
-    (1) Return the PostGres datatype of a given column
+    (1) Return the Postgres datatype of a given column
     (2) Determine whether that datatype fits into the broad category of either:
         (a) numeric data
         (b) character data
@@ -11,7 +11,7 @@ import sys
 import traceback
 import logging
 import psycopg2
-from geonode.contrib.msg_util import msg, msgt
+#from geonode.contrib.msg_util import msg, msgt
 from geonode.contrib.datatables.db_helper import get_datastore_connection_string
 
 LOGGER = logging.getLogger('geonode.contrib.datatables.column_helper')
@@ -25,7 +25,13 @@ POSTGRES_NUMERIC_DATATYPES = ('smallint', 'integer', 'bigint', 'decimal',\
 
 
 class ColumnHelper(object):
-
+    """
+    Convenience methods to:
+        (1) Return the Postgres datatype of a given column
+        (2) Determine whether that datatype fits into the broad category of either:
+            (a) numeric data
+            (b) character data
+    """
     @staticmethod
     def get_column_datatype(table_name, table_attribute):
         """
@@ -67,7 +73,8 @@ class ColumnHelper(object):
         makes it into a number
         """
 
-        success, data_type_or_err_msg = ColumnHelper.get_column_datatype(table_name, table_attribute)
+        success, data_type_or_err_msg =\
+            ColumnHelper.get_column_datatype(table_name, table_attribute)
         if success:
             return (True, ColumnHelper.is_character_column(data_type_or_err_msg))
         else:

--- a/geonode/contrib/datatables/db_helper.py
+++ b/geonode/contrib/datatables/db_helper.py
@@ -1,9 +1,8 @@
 from django.conf import settings
-from collections import OrderedDict
 
 from geonode.maps import utils
 
-DB_PARAM_NAMES = ['NAME', 'USER', 'PASSWORD', 'PORT','HOST']
+DB_PARAM_NAMES = ['NAME', 'USER', 'PASSWORD', 'PORT', 'HOST']
 
 CHOSEN_DB_SETTING = 'wmdata'
 DATAVERSE_DB = settings.DB_DATAVERSE_NAME
@@ -28,12 +27,14 @@ def get_datastore_connection_string(url_format=False, is_dataverse_db=True, db_n
 
     e.g. "dbname='wmdb' user='username' password='the-pw' port=123 host=db.hostname.edu"
     """
-    global DB_PARAM_NAMES, CHOSEN_DB_SETTING
+    # global DB_PARAM_NAMES, CHOSEN_DB_SETTING
 
     db_params = settings.DATABASES[CHOSEN_DB_SETTING]
 
     for attr in DB_PARAM_NAMES:
-        assert db_params.has_key(attr), "Check your settings file. DATABASES['default'] does not specify a '%s'" % attr
+        assert db_params.has_key(attr),\
+            ("Check your settings file. DATABASES['default']"
+             " does not specify a '%s'") % (attr)
 
 
     # if in production, we rewrite db_param['NAME'] depending on a few situations
@@ -45,11 +46,16 @@ def get_datastore_connection_string(url_format=False, is_dataverse_db=True, db_n
         db_params['NAME'] = get_database_name(is_dataverse_db)
 
     if url_format:
-        # connection_string = "postgresql://%s:%s@%s:%s/%s" % (db['USER'], db['PASSWORD'], db['HOST'], db['PORT'], db['NAME'])
+        # connection_string = "postgresql://%s:%s@%s:%s/%s" % (db['USER'],
+        # db['PASSWORD'], db['HOST'], db['PORT'], db['NAME'])
         conn_str = "postgresql://%s:%s@%s:%s/%s" % \
-                        (db_params['USER'], db_params['PASSWORD'], db_params['HOST'], db_params['PORT'], db_params['NAME'])
+                        (db_params['USER'],
+                         db_params['PASSWORD'],
+                         db_params['HOST'],
+                         db_params['PORT'],
+                         db_params['NAME'])
     else:
-        conn_str = """dbname='%s' user='%s' password='%s' port=%s host='%s'""" % \
+        conn_str = """dbname='%s' user='%s' password='%s' port=%s host='%s'""" %\
                     tuple([db_params.get(x) for x in DB_PARAM_NAMES])
 
 

--- a/geonode/contrib/datatables/models.py
+++ b/geonode/contrib/datatables/models.py
@@ -206,7 +206,7 @@ class JoinTarget(models.Model):
     layer = models.ForeignKey(Layer)
     attribute = models.ForeignKey(LayerAttribute)
     geocode_type = models.ForeignKey(GeocodeType, on_delete=models.PROTECT)
-    expected_format = models.ForeignKey(JoinTargetFormatType, null=True, blank=True)
+    expected_format = models.ForeignKey(JoinTargetFormatType)
     year = models.IntegerField()
 
     created = models.DateTimeField(auto_now_add=True)

--- a/geonode/contrib/datatables/utils.py
+++ b/geonode/contrib/datatables/utils.py
@@ -380,21 +380,21 @@ def setup_join(new_table_owner, table_name, layer_typename,
     # ------------------------------------------------------------------
     # Retrieve stats
     # ------------------------------------------------------------------
-    matched_count_sql = ('select count({0}) from {1} where {1}.{2}'
+    matched_count_sql = ('select count({0}) from {1} where {1}.{0}'
                          ' in (select "{2}" from {3});').format(\
                             table_attribute.attribute,
                             dt.table_name,
                             layer_attribute.attribute,
                             layer_name)
 
-    unmatched_count_sql = ('select count({0}) from {1} where {1}.{2}'
+    unmatched_count_sql = ('select count({0}) from {1} where {1}.{0}'
                            ' not in (select "{2}" from {3});').format(\
                             table_attribute.attribute,
                             dt.table_name,
                             layer_attribute.attribute,
                             layer_name)
 
-    unmatched_list_sql = ('select{0} from {1} where {1}.{2}'
+    unmatched_list_sql = ('select {0} from {1} where {1}.{0}'
                           ' not in (select "{2}" from {3}) limit 500;').format(\
                             table_attribute.attribute,
                             dt.table_name,

--- a/geonode/contrib/datatables/utils.py
+++ b/geonode/contrib/datatables/utils.py
@@ -117,7 +117,6 @@ def process_csv_file(data_table,
         # Iterate through header row
         #
         for column in csv_table:
-
             # Standardize column name
             #
             column.name = standardize_column_name(column.name)
@@ -633,6 +632,12 @@ def attempt_datatable_upload_from_request_params(request,\
     table_name = get_unique_tablename(splitext(basename(request.FILES['uploaded_file'].name))[0])
 
     delimiter = data['delimiter']
+
+    # cheap fix for an error where the
+    # delimiter tab isn't going through
+    if delimiter == '\\':
+        delimiter = '\t'
+
     # only joins go to dataverse db
     database = get_database_name(is_dataverse_db)
     instance = DataTable(uploaded_file=request.FILES['uploaded_file'],

--- a/geonode/contrib/datatables/utils_lat_lng.py
+++ b/geonode/contrib/datatables/utils_lat_lng.py
@@ -201,7 +201,7 @@ def create_point_col_from_lat_lon(new_table_owner, table_name, lat_column, lng_c
                 ds = datastore
 
         if ds is None:
-            err_msg = "Datastore '%s' not found" % (settings.DB_DATASTORE_NAME)
+            err_msg = "Datastore not found: '%s' (lat/lng)" % (settings.DB_DATASTORE_NAME)
             return False, err_msg
         ft = cat.publish_featuretype(table_name, ds, "EPSG:4326", srs="EPSG:4326")
         cat.save(ft)

--- a/geonode/contrib/dataverse_connect/layer_metadata.py
+++ b/geonode/contrib/dataverse_connect/layer_metadata.py
@@ -40,7 +40,7 @@ srs=EPSG
 
 """
 
-class LayerMetadata:
+class LayerMetadata(object):
     """
     Prepare Layer Metadata to send back to Geoconnect, and then the Dataverse.
 
@@ -102,7 +102,7 @@ class LayerMetadata:
             print '%s: (%s)' % (k, v)
         print '-'
         '''
-        
+
         if as_json:
             try:
                 return json.dumps(params)
@@ -148,7 +148,7 @@ class LayerMetadata:
         #self.srs = layer_obj.srs
         self.attribute_info = self.get_attribute_metadata(layer_obj)
         if layer_obj.owner:
-            self.worldmap_username =  layer_obj.owner.username
+            self.worldmap_username = layer_obj.owner.username
 
         download_links_dict = self.format_download_links(layer_obj)
         if download_links_dict:
@@ -166,7 +166,7 @@ class LayerMetadata:
     def format_download_links(self, layer_obj):
         assert type(layer_obj) is Layer, "layer_obj must be type Layer"
 
-        if not hasattr(layer_obj, 'resource'):
+        if layer_obj.resource is None:
             return None
         if not hasattr(layer_obj.resource, 'resource_type'):
             return None

--- a/geonode/contrib/dataverse_connect/views.py
+++ b/geonode/contrib/dataverse_connect/views.py
@@ -10,23 +10,25 @@ from django.views.decorators.csrf import csrf_exempt
 from django.core.files.uploadedfile import TemporaryUploadedFile, InMemoryUploadedFile
 from django.core.exceptions import ValidationError
 
+from shared_dataverse_information.shared_form_util.format_form_errors import format_errors_as_text
+from shared_dataverse_information.shapefile_import.forms import ShapefileImportDataForm
+
 from geonode.maps.utils import save
 from geonode.maps.views import _create_new_user
 from geonode.utils import slugify
 
 from geonode.contrib.basic_auth_decorator import http_basic_auth_for_api
-from geonode.contrib.dataverse_connect.layer_metadata import LayerMetadata        # object with layer metadata
-from geonode.contrib.dataverse_connect.dv_utils import MessageHelperJSON          # format json response object
+from geonode.contrib.dataverse_connect.layer_metadata import LayerMetadata
+from geonode.contrib.dataverse_connect.dv_utils import MessageHelperJSON
 
-from geonode.contrib.dataverse_layer_metadata.layer_metadata_helper import add_dataverse_layer_metadata, check_for_existing_layer, update_the_layer_metadata
+from geonode.contrib.dataverse_layer_metadata.layer_metadata_helper import\
+        add_dataverse_layer_metadata,\
+        check_for_existing_layer,\
+        update_the_layer_metadata
 
+#from geonode.contrib.dataverse_permission_links.models import DataversePermissionLink
 
-from shared_dataverse_information.shared_form_util.format_form_errors import format_errors_as_text
-
-#from geonode.contrib.dataverse_connect.forms import ShapefileImportDataForm
-from shared_dataverse_information.shapefile_import.forms import ShapefileImportDataForm
-
-logger = logging.getLogger("geonode.contrib.dataverse_connect.views")
+LOGGER = logging.getLogger("geonode.contrib.dataverse_connect.views")
 
 
 @csrf_exempt
@@ -44,53 +46,60 @@ def view_add_worldmap_shapefile(request):
     """
     Process a Dataverse POST request to create a Layer with an accompanying LayerMetadata object
     """
-    #print request.POST.values()
-
-    #print "view_add_worldmap_shapefile"
-
     #   Is this request a POST?
     #
     if not request.POST:
-        json_msg = MessageHelperJSON.get_json_msg(success=False, msg="The request must be a POST.")
-        return HttpResponse(status=401, content=json_msg, content_type="application/json")
+        json_msg = MessageHelperJSON.get_json_msg(\
+                            success=False,
+                            msg="The request must be a POST.")
+        return HttpResponse(status=401,
+                            content=json_msg,
+                            content_type="application/json")
 
 
     #   Does the request have proper auth?
     #   -> check is now done by the ShapefileImportDataForm
 
-
     #   Is there a file in this request
     #
-    if (not request.FILES) or len(request.FILES)==0:
-        logger.error("Shapefile import error.  No FILES in request")
+    if (not request.FILES) or len(request.FILES) == 0:
+        LOGGER.error("Shapefile import error.  No FILES in request")
         json_msg = MessageHelperJSON.get_json_msg(success=False\
                                 , msg="File not found.  Did you send a file?")
 
-        return HttpResponse(status=400, content=json_msg, content_type="application/json")
+        return HttpResponse(status=400,
+                            content=json_msg,
+                            content_type="application/json")
 
-    if not len(request.FILES)==1:
-        logger.error("Shapefile import error.  Only send 1 file")
-        json_msg = MessageHelperJSON.get_json_msg(success=False\
-                                , msg="This request only accepts a single file")
+    if not len(request.FILES) == 1:
+        LOGGER.error("Shapefile import error.  Only send 1 file")
+        json_msg = MessageHelperJSON.get_json_msg(\
+                                success=False,
+                                msg="This request only accepts a single file")
 
-        return HttpResponse(status=400, content=json_msg, content_type="application/json")
-
-
+        return HttpResponse(status=400,
+                            content=json_msg,
+                            content_type="application/json")
 
     Post_Data_As_Dict = request.POST.dict()
 
     #   Is this a valid request?  Check parameters.
     #
-    form_shapefile_import= ShapefileImportDataForm(Post_Data_As_Dict)
+    form_shapefile_import = ShapefileImportDataForm(Post_Data_As_Dict)
     if not form_shapefile_import.is_valid():
         #
         #   Invalid, send back an error message
         #
-        logger.error("Shapefile import error: \n%s" % format_errors_as_text(form_shapefile_import))
-        json_msg = MessageHelperJSON.get_json_msg(success=False\
-                                , msg="Incorrect params for ShapefileImportDataForm: <br />%s" % form_shapefile_import.errors)
+        LOGGER.error("Shapefile import error: \n%s",\
+                     format_errors_as_text(form_shapefile_import))
+        json_msg = MessageHelperJSON.get_json_msg(\
+                    success=False,
+                    msg=('Incorrect params for ShapefileImportDataForm:'
+                         ' <br />%s') % form_shapefile_import.errors)
 
-        return HttpResponse(status=400, content=json_msg, content_type="application/json")
+        return HttpResponse(status=400,
+                            content=json_msg,
+                            content_type="application/json")
 
     #-----------------------------------------------------------
     #   start: check for existing layer
@@ -98,15 +107,20 @@ def view_add_worldmap_shapefile(request):
     #   Check for an existing DataverseLayerMetadata object.
     #-----------------------------------------------------------
     existing_dv_layer_metadata = None
-    logger.info("pre existing layer check")
+    LOGGER.info("pre existing layer check")
     try:
         existing_dv_layer_metadata = check_for_existing_layer(Post_Data_As_Dict)
-        logger.info("found existing layer")
+        LOGGER.info("found existing layer")
     except ValidationError as e:
         error_msg = "The dataverse information failed validation: %s" % Post_Data_As_Dict
-        logger.error(error_msg)
-        json_msg = MessageHelperJSON.get_json_msg(success=False, msg="(The WorldMap could not verify the data.)")
-        return HttpResponse(status=400, content=json_msg, content_type="application/json")
+        LOGGER.error(error_msg)
+
+        json_msg = MessageHelperJSON.get_json_msg(\
+                        success=False,
+                        msg="(The WorldMap could not verify the data.)")
+
+        return HttpResponse(status=400,
+                            content=json_msg, content_type="application/json")
 
     #-----------------------------------------------------------
     #   end: check for existing layer
@@ -115,16 +129,19 @@ def view_add_worldmap_shapefile(request):
     #   * Update the worldmap user? *
     #-----------------------------------------------------------
     if existing_dv_layer_metadata:
-        logger.info("Found existing layer!")
+        LOGGER.info("Found existing layer!")
 
         update_the_layer_metadata(existing_dv_layer_metadata, Post_Data_As_Dict)
 
-        layer_metadata_obj = LayerMetadata( existing_dv_layer_metadata.map_layer)
+        layer_metadata_obj = LayerMetadata(existing_dv_layer_metadata.map_layer)
 
-        json_msg = MessageHelperJSON.get_json_msg(success=True, msg='worked', data_dict=layer_metadata_obj.get_metadata_dict())
-        return HttpResponse(status=200, content=json_msg, content_type="application/json")
-
-
+        json_msg = MessageHelperJSON.get_json_msg(\
+                            success=True,
+                            msg='worked',
+                            data_dict=layer_metadata_obj.get_metadata_dict())
+        return HttpResponse(status=200,
+                            content=json_msg,
+                            content_type="application/json")
 
     #
     #   Using the ShapefileImportDataForm,
@@ -149,7 +166,7 @@ def view_add_worldmap_shapefile(request):
 
     #   Format file name and save actual file
     #
-    shapefile_name = slugify(shapefile_name.replace(".","_"))
+    shapefile_name = slugify(shapefile_name.replace(".", "_"))
     file_obj = write_the_dataverse_file(transferred_file)
     #print ('file_obj', file_obj)
 
@@ -161,23 +178,26 @@ def view_add_worldmap_shapefile(request):
     #   a random string at the end
     new_layer_name = shapefile_name[:10]
     try:
-        saved_layer = save(new_layer_name,\
-                           file_obj,\
-                           user_object,\
-                           overwrite = False,\
-                           abstract = abstract,\
-                           title = title,\
-                           keywords = keywords.split()\
-                        )
+        saved_layer = save(new_layer_name,
+                           file_obj,
+                           user_object,
+                           overwrite=False,
+                           abstract=abstract,
+                           title=title,
+                           keywords=keywords.split())
 
         # ------------------------------------------
         # Look for DataverseInfo in the Post_Data_As_Dict
         #   If it exists, create a DataverseLayerMetadata object
         # ------------------------------------------
-        dataverse_layer_metadata = add_dataverse_layer_metadata(saved_layer, Post_Data_As_Dict)
+        dataverse_layer_metadata = add_dataverse_layer_metadata(\
+                                        saved_layer, Post_Data_As_Dict)
+
         if dataverse_layer_metadata is None:
-            logger.error("Failed to create a DataverseLayerMetadata object")
-            json_msg = MessageHelperJSON.get_json_msg(success=False, msg="Failed to create a DataverseLayerMetadata object")
+            LOGGER.error("Failed to create a DataverseLayerMetadata object")
+            json_msg = MessageHelperJSON.get_json_msg(\
+                            success=False,
+                            msg="Failed to create a DataverseLayerMetadata object")
 
             # remove the layer
             #
@@ -193,7 +213,10 @@ def view_add_worldmap_shapefile(request):
         layer_metadata_obj = LayerMetadata(saved_layer)
 
         # Return the response!
-        json_msg = MessageHelperJSON.get_json_msg(success=True, msg='Shapefile successfully imported', data_dict=layer_metadata_obj.get_metadata_dict())
+        json_msg = MessageHelperJSON.get_json_msg(\
+                        success=True,
+                        msg='Shapefile successfully imported',
+                        data_dict=layer_metadata_obj.get_metadata_dict())
         #print '-' * 40
         #print 'json_msg', json_msg
 
@@ -201,7 +224,8 @@ def view_add_worldmap_shapefile(request):
 
     except:
         e = sys.exc_info()[0]
-        logger.error("Unexpected error during dvn import: %s : %s" % (shapefile_name, escape(str(e))))
+        LOGGER.error("Unexpected error during dvn import: %s : %s",\
+                     shapefile_name, escape(str(e)))
         err_msg = "Unexpected error during upload: %s" %  escape(str(e))
         json_msg = MessageHelperJSON.get_json_msg(success=False, msg=err_msg)
         return HttpResponse(status=500, content=json_msg, content_type="application/json")
@@ -213,15 +237,18 @@ def write_the_dataverse_file(temp_uploaded_file):
     Save the uploaded dataverse file to disk
     """
     assert type(temp_uploaded_file) in (InMemoryUploadedFile, TemporaryUploadedFile)\
-        , 'temp_uploaded_file" must be type "django.core.files.uploadedfile.TemporaryUploadedFile or InMemoryUploadedFile.  Found type: %s' % type(temp_uploaded_file)
+                , ('temp_uploaded_file" must be type'
+                   ' django.core.files.uploadedfile.TemporaryUploadedFile'
+                   ' or InMemoryUploadedFile.  Found type: %s'\
+                   % type(temp_uploaded_file))
 
     #print 'file type', type(temp_uploaded_file)
 
     tempdir = tempfile.mkdtemp()
     path = os.path.join(tempdir, temp_uploaded_file.name)
     with open(path, 'w') as writable:
-        for c in temp_uploaded_file.chunks():
-            writable.write(c)
+        for fchunk in temp_uploaded_file.chunks():
+            writable.write(fchunk)
     return path
 
 
@@ -241,7 +268,7 @@ def get_worldmap_user_object(worldmap_username, dv_user_email):
         try:
             user_object = User.objects.get(username=worldmap_username)
             return user_object
-        except:
+        except Exception:
             pass
 
     if dv_user_email:
@@ -251,8 +278,8 @@ def get_worldmap_user_object(worldmap_username, dv_user_email):
 
     try:
         return _create_new_user(dv_user_email, None, None, None)
-    except:
-        logger.error('_create_new_user failed with email: %s' % dv_user_email)
+    except Exception:
+        LOGGER.error('_create_new_user failed with email: %s', dv_user_email)
 
     return None
 """
@@ -266,7 +293,7 @@ if dataverse_layer_metadata.dataset_is_public is False:
         #
         # Failed to set privacy permissions, remove layer
         #
-        logger.error("Failed to set privacy permissions.  Deleting layer")
+        LOGGER.error("Failed to set privacy permissions.  Deleting layer")
         saved_layer.delete()
         json_msg = MessageHelperJSON.get_json_msg(success=False, msg="Failed to set privacy permissions.  Deleting layer")
         return HttpResponse(status=200, content=json_msg, content_type="application/json")

--- a/geonode/contrib/dataverse_layer_metadata/layer_metadata_helper.py
+++ b/geonode/contrib/dataverse_layer_metadata/layer_metadata_helper.py
@@ -8,14 +8,15 @@ from shared_dataverse_information.shapefile_import.forms import ShapefileImportD
 
 from geonode.maps.models import Layer
 
-logger = logging.getLogger("geonode.dataverse_layer_metadata.layer_metadata_helper")
+LOGGER = logging.getLogger("geonode.dataverse_layer_metadata.layer_metadata_helper")
 
 
 def check_for_existing_layer(dataverse_info):
     """
     Using the dataverse_info information
 
-    Does the datafile_id and dataverse_installation_name in dataverse_info match an existing DataverseLayerMetadata object?
+    Do the datafile_id and dataverse_installation_name
+    in dataverse_info match an existing DataverseLayerMetadata object?
 
     Yes:  return first matching DataverseLayerMetadata object
     No: return None
@@ -26,14 +27,15 @@ def check_for_existing_layer(dataverse_info):
     # Validate the data
     f = DataverseLayerMetadataValidationForm(dataverse_info)
     if not f.is_valid():
-        logger.error('check_for_existing_layer. failed validation')
-        logger.error('Errors: %s' % f.errors)
+        LOGGER.error('check_for_existing_layer. failed validation')
+        LOGGER.error('Errors: %s' % f.errors)
         raise forms.ValidationError('Failed to validate dataverse_info data')
 
-    # Check for DataverseLayerMetadata objects with the same "datafile_id" AND "dataverse_installation_name"
-    l = DataverseLayerMetadata.objects.filter(datafile_id=f.cleaned_data.get('datafile_id')\
-                                , dataverse_installation_name=f.cleaned_data.get('dataverse_installation_name')\
-                                )
+    # Check for DataverseLayerMetadata objects with
+    # the same "datafile_id" AND "dataverse_installation_name"
+    l = DataverseLayerMetadata.objects.filter(\
+          datafile_id=f.cleaned_data.get('datafile_id'),
+          dataverse_installation_name=f.cleaned_data.get('dataverse_installation_name'))
 
     # If DataverseLayerMetadata objects match, return the 1st one
     # (Note: Not ~yet~ enforcing only 1 DataverseLayerMetadata per datafile_id.
@@ -47,15 +49,19 @@ def check_for_existing_layer(dataverse_info):
 
 
 def retrieve_dataverse_layer_metadata_by_kwargs_installation_and_file_id(**kwargs):
+    """Retrieve Dataverse Layer based on installation id and file id"""
     if kwargs is None:
         return None
 
     datafile_id = kwargs.get('datafile_id', None)
     dataverse_installation_name = kwargs.get('dataverse_installation_name', None)
 
-    return retrieve_dataverse_layer_metadata_by_installation_and_file_id(datafile_id, dataverse_installation_name)
+    return retrieve_dataverse_layer_metadata_by_installation_and_file_id(\
+                datafile_id, dataverse_installation_name)
 
-def retrieve_dataverse_layer_metadata_by_installation_and_file_id(datafile_id, dataverse_installation_name):
+
+def retrieve_dataverse_layer_metadata_by_installation_and_file_id(\
+            datafile_id, dataverse_installation_name):
     """
     Retrieve a GeoNode layer by an associated DataverseInfo object identified by:
         - datafile_id
@@ -67,9 +73,9 @@ def retrieve_dataverse_layer_metadata_by_installation_and_file_id(datafile_id, d
     if datafile_id is None or dataverse_installation_name is None:
         return None
 
-    l = DataverseLayerMetadata.objects.filter(datafile_id=datafile_id,
-                                        dataverse_installation_name=dataverse_installation_name
-                                    )
+    l = DataverseLayerMetadata.objects.filter(\
+                        datafile_id=datafile_id,
+                        dataverse_installation_name=dataverse_installation_name)
 
     # If DataverseLayerMetadata objects match, return the 1st one
     #  - Should only be 1 layer
@@ -80,12 +86,14 @@ def retrieve_dataverse_layer_metadata_by_installation_and_file_id(datafile_id, d
     return None
 
 
-
-
 def update_the_layer_metadata(dv_layer_metadata, dataverse_info):
+    """Update the DataverseLayerMetadata object with given DataverseInfo"""
+    assert type(dv_layer_metadata) is DataverseLayerMetadata,\
+            ('dv_layer_metadata must be a DataverseLayerMetadata'
+             ' object.  Found type: %s' % type(dv_layer_metadata))
 
-    assert type(dv_layer_metadata) is DataverseLayerMetadata, "dv_layer_metadata must be a DataverseLayerMetadata object.  Found type: %s" % type(dv_layer_metadata)
-    assert type(dataverse_info) is dict, "dataverse_info must be type dict. Found type: %s" % type(dataverse_info)
+    assert type(dataverse_info) is dict,\
+            "dataverse_info must be type dict. Found type: %s" % type(dataverse_info)
 
     # Validate the data
     f = DataverseLayerMetadataValidationForm(dataverse_info)
@@ -101,7 +109,7 @@ def update_the_layer_metadata(dv_layer_metadata, dataverse_info):
     #   Using the 'ShapefileImportDataForm' is a bit redundant,
     #      but not sure where updates will arise in the future
     #
-    f2= ShapefileImportDataForm(dataverse_info)
+    f2 = ShapefileImportDataForm(dataverse_info)
     if not f2.is_valid():
         raise forms.ValidationError('Failed to validate form_shapefile_import data')
 
@@ -117,36 +125,38 @@ def add_dataverse_layer_metadata(saved_layer, dataverse_info):
     fail: return None
     success: return DataverseLayerMetadata object
     """
-    assert type(saved_layer) is Layer, "saved_layer must be type Layer.  Found: %s" % type(Layer)
-    assert type(dataverse_info) is dict, "dataverse_info must be type dict. Found type: %s" % type(dataverse_info)
+    assert type(saved_layer) is Layer,\
+        "saved_layer must be type Layer.  Found: %s" % type(Layer)
+    assert type(dataverse_info) is dict,\
+        "dataverse_info must be type dict. Found type: %s" % type(dataverse_info)
 
-    (success, create_datetime_obj_or_err_str) = DataverseLayerMetadataValidationForm.format_datafile_create_datetime(dataverse_info.get('datafile_create_datetime', None))
+    (success, create_datetime_obj_or_err_str) =\
+        DataverseLayerMetadataValidationForm.format_datafile_create_datetime(\
+                        dataverse_info.get('datafile_create_datetime', None))
 
     if success is False:
         print ('failed to format datetime', create_datetime_obj_or_err_str)
-        logger.error('Invalid "datafile_create_datetime"\n%s' % create_datetime_obj_or_err_str)
+        LOGGER.error('Invalid "datafile_create_datetime"\n%s', create_datetime_obj_or_err_str)
         return None
 
     dataverse_info['datafile_create_datetime'] = create_datetime_obj_or_err_str
 
     f = DataverseLayerMetadataValidationForm(dataverse_info)
-    #print (dir(f))
     if not f.is_valid():
         print ('failed validation')
         print (f.errors)
-        logger.error("Unexpected form validation error in add_dataverse_layer_metadata. dvn import: %s" % f.errors)
+        LOGGER.error(('Unexpected form validation error'
+                      ' in add_dataverse_layer_metadata. dvn import: %s'),\
+                      f.errors)
         return None
-
 
     # Create the DataverseLayerMetadata object
     layer_metadata = f.save(commit=False)
-
 
     # Add the related Layer object
     layer_metadata.map_layer = saved_layer
 
     # Save it!!
     layer_metadata.save()
-    
+
     return layer_metadata
-    

--- a/geonode/contrib/dataverse_layer_metadata/models.py
+++ b/geonode/contrib/dataverse_layer_metadata/models.py
@@ -4,19 +4,22 @@ from shared_dataverse_information.dataverse_info.models import DataverseInfo
 
 class DataverseLayerMetadata(DataverseInfo):
     """
-    If a map layer is created using a dataverse file, 
+    If a map layer is created using a dataverse file,
     this objects contains Dataverse specific info on the file.
-    
-    In addition to supplying metadata, it can also be used to identify 
+
+    In addition to supplying metadata, it can also be used to identify
     which Layers were created using Dataverse files.
+
+    If the Layer is deleted, remove this DataverseMetadata object
     """
-    map_layer = models.ForeignKey(Layer, on_delete=models.CASCADE)      # if the Layer is deleted, remove this DataverseMetadata object
-    
-    
+    map_layer = models.ForeignKey(Layer,
+                                  on_delete=models.CASCADE)
+
     def __unicode__(self):
-        return '%s (%s -> %s)' % (self.datafile_label, self.dataverse_name, self.dataset_name)
-        
+        return '%s (%s -> %s)' % (self.datafile_label,
+                                  self.dataverse_name,
+                                  self.dataset_name)
+
     class Meta:
         ordering = ('-modified',  )
         verbose_name_plural = 'Dataverse Metadata'
-    

--- a/geonode/contrib/dataverse_permission_links/admin.py
+++ b/geonode/contrib/dataverse_permission_links/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from geonode.contrib.dataverse_permission_links.models import DataversePermissionLink
+from geonode.contrib.dataverse_permission_links.forms import DataversePermissionLinkForm
+
+class DataversePermissionLinkAdmin(admin.ModelAdmin):
+    form = DataversePermissionLinkForm
+    save_on_top = True
+    search_fields = ('dataverse_username',  'worldmap_username')
+    list_display = ('name',
+                    'is_active',
+                    'dataverse_username',
+                    'worldmap_username',
+                    'worldmap_user',
+                    'modified',
+                    'created')
+
+    list_filter = ('is_active',)
+    readonly_fields = ('modified', 'created',)
+
+admin.site.register(DataversePermissionLink, DataversePermissionLinkAdmin)

--- a/geonode/contrib/dataverse_permission_links/forms.py
+++ b/geonode/contrib/dataverse_permission_links/forms.py
@@ -5,13 +5,28 @@ from django.contrib.auth.models import User
 
 class DataversePermissionLinkForm(forms.ModelForm):
 
+    def clean_dataverse_username(self):
+        """Strip whitespace from username"""
+        dataverse_username = self.cleaned_data.get('dataverse_username', None)
+        if dataverse_username is None:
+            raise forms.ValidationError("Please enter a Dataverse username.")
+
+        dataverse_username = dataverse_username.strip()
+        if len(dataverse_username) == 0:
+            raise forms.ValidationError("Please enter a Dataverse username.")
+
+        return dataverse_username
+
     def clean_worldmap_username(self):
+        """Make sure the worldmap username maps to an actual User object"""
 
         worldmap_username = self.cleaned_data.get('worldmap_username', None)
         if worldmap_username is None:
             raise forms.ValidationError("Please enter a WorldMap username.")
 
         worldmap_username = worldmap_username.strip()
+        if len(worldmap_username) == 0:
+            raise forms.ValidationError("Please enter a WorldMap username.")
 
         # Check if the username is valid
         try:

--- a/geonode/contrib/dataverse_permission_links/forms.py
+++ b/geonode/contrib/dataverse_permission_links/forms.py
@@ -1,0 +1,49 @@
+from django import forms
+from django.contrib.auth.models import User
+
+
+
+class DataversePermissionLinkForm(forms.ModelForm):
+
+    def clean_worldmap_username(self):
+
+        worldmap_username = self.cleaned_data.get('worldmap_username', None)
+        if worldmap_username is None:
+            raise forms.ValidationError("Please enter a WorldMap username.")
+
+        worldmap_username = worldmap_username.strip()
+
+        # Check if the username is valid
+        try:
+            worldmap_user = User.objects.get(username=worldmap_username)
+            return worldmap_username
+        except User.DoesNotExist:
+            raise forms.ValidationError(\
+                'That WorldMap username does not exist. ("%s")' % worldmap_username)
+
+    def __init__(self, *args, **kwargs):
+        """Limit WorldMap user drop down to only the selected choice"""
+        super(DataversePermissionLinkForm, self).__init__(*args, **kwargs)
+
+        selected_worldmap_user_id = kwargs.get('initial', {}).get('worldmap_user', None)
+
+        # Is this an existing/saved DataversePermissionLinkForm
+        #
+        if self.instance and self.instance.id:
+            # Yes, limit choices to the chosen WorldMap user
+            #
+            self.fields['worldmap_user'].queryset = User.objects.filter(\
+                                        pk=self.instance.worldmap_user.id)
+
+        elif selected_worldmap_user_id and selected_worldmap_user_id.isdigit():
+            self.fields['worldmap_user'].queryset = User.objects.filter(\
+                                        pk=selected_worldmap_user_id)
+
+
+        elif 'initial' in kwargs:
+            # We can't "afford" to list everything.
+            # Don't list any Users
+            #   - An admin template instructs the user on how
+            #       to add a new JoinTarget via the Layer admin
+            #
+            self.fields['worldmap_user'].queryset = User.objects.none()

--- a/geonode/contrib/dataverse_permission_links/models.py
+++ b/geonode/contrib/dataverse_permission_links/models.py
@@ -5,8 +5,6 @@ Allow specified Dataverse users who also have WorldMap credentials to:
 reference: https://github.com/IQSS/dataverse/issues/3469
 """
 from django.db import models
-from geonode.maps.models import Layer
-from shared_dataverse_information.dataverse_info.models import DataverseInfo
 from django.contrib.auth.models import User
 
 class DataversePermissionLink(models.Model):

--- a/geonode/contrib/dataverse_permission_links/models.py
+++ b/geonode/contrib/dataverse_permission_links/models.py
@@ -49,7 +49,7 @@ class DataversePermissionLink(models.Model):
             raise Exception('Username does not exist: %s' % worldmap_username)
 
         if self.worldmap_user:
-            self.name = '%s - %s' % (self.dataverse_username,
+            self.name = '%s <--> %s' % (self.dataverse_username,
                                      self.worldmap_user.username)
             self.name = self.name[:255]
 

--- a/geonode/contrib/dataverse_permission_links/models.py
+++ b/geonode/contrib/dataverse_permission_links/models.py
@@ -1,0 +1,68 @@
+"""
+Allow specified Dataverse users who also have WorldMap credentials to:
+ - Edit their Dataverse-created layers by logging into WorldMap
+
+reference: https://github.com/IQSS/dataverse/issues/3469
+"""
+from django.db import models
+from geonode.maps.models import Layer
+from shared_dataverse_information.dataverse_info.models import DataverseInfo
+from django.contrib.auth.models import User
+
+class DataversePermissionLink(models.Model):
+    """
+    Scenario: A user maps a data file via the Dataverse-WorldMap connection.
+    This results in a new layer.
+
+    "Usual case"
+    - Normally, these new layers are owned by a Dataverse service account.
+    (This service account is a "normal" WorldMap account)
+
+    "Extra Permissions Case"
+    - In some cases case, ownership permissions for the new layer should
+    also be given to additional WorldMap users, such as the BARI WorldMap user
+
+    """
+    name = models.CharField(max_length=255,
+                            blank=True,
+                            help_text='auto-filled on save')
+
+    dataverse_username = models.CharField('Dataverse username',
+                                          max_length=255)
+
+    worldmap_username = models.CharField('Worldmap username',
+                                         max_length=255,
+                                         help_text='(Validated on save)')
+    worldmap_user = models.ForeignKey(User,
+                                      blank=True,
+                                      null=True,
+                                      help_text='auto-filled on save')
+
+    is_active = models.BooleanField(default=True)
+    description = models.TextField(blank=True, help_text='optional')
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
+
+    def save(self, *args, **kwargs):
+        """Set the name attribute on save"""
+        try:
+            self.worldmap_user = User.objects.get(username=self.worldmap_username)
+        except:
+            raise Exception('Username does not exist: %s' % worldmap_username)
+
+        if self.worldmap_user:
+            self.name = '%s - %s' % (self.dataverse_username,
+                                     self.worldmap_user.username)
+            self.name = self.name[:255]
+
+        super(DataversePermissionLink, self).save(*args, **kwargs)
+
+    def __unicode__(self):
+        if not self.name:
+            return 'dv-wm link (un named)'
+        return self.name
+
+    class Meta:
+        """Model Meta info"""
+        unique_together = ('dataverse_username', 'worldmap_user')
+        db_table = 'dataverse_permission_links'

--- a/geonode/contrib/dataverse_permission_links/permission_setter.py
+++ b/geonode/contrib/dataverse_permission_links/permission_setter.py
@@ -1,0 +1,99 @@
+"""
+For a Dataverse-created map, check if additional users
+should have edit permissions
+"""
+from django.shortcuts import get_object_or_404
+
+from geonode.maps.models import Layer
+from geonode.core.models import PermissionLevelMixin
+
+from geonode.contrib.dataverse_permission_links.models import DataversePermissionLink
+
+
+class PermissionLinker(object):
+    """
+    For a Dataverse-created map, check if additional users
+    should have edit permissions
+    """
+
+    def __init__(self, layer_name, dataverse_username):
+        """
+        layer_name: e.g. "geonode:j_cbg_annual_census_bloc_1z"
+        dv_username: from DatavereLayerMetadata.dv_username
+        """
+        self.layer_name = layer_name
+        self.dv_username = dataverse_username
+
+        # Most layers will not be linked to additional
+        # WorldMap credentials
+        self.was_layer_linked = False
+
+        # Hold error messages
+        self.has_error = False
+        self.error_message = None
+
+        # If appropriate, link the layer
+        self.sanity_check()
+
+
+    def add_error(self, err_msg):
+        """Add error message"""
+        self.has_error = True
+        self.error_message = err_msg
+
+    def sanity_check(self):
+        """Check for null values"""
+        if self.layer_name is None:
+            self.add_error("layer_name cannot be None")
+            return False
+
+        if self.dv_username is None:
+            self.add_error("dv_username cannot be None")
+            return False
+
+        return True
+
+    def link_layer(self):
+        if self.has_error:
+            return False
+
+        # (1) Retrieve the PermissionLink(s)
+        #
+        filter_params = dict(dataverse_username=self.dv_username,
+                          is_active=True)
+        perm_links = DataversePermissionLink.objects.filter(**filter_params)
+        if len(perm_links) == 0:
+            # Most times, there are no links, this is OK
+            return True
+
+        # (2) Retrieve the Map Layer
+        #
+        try:
+            map_obj = Layer.objects.get(typename=self.layer_name)
+        except Layer.DoesNotExist:
+            self.add_error("The layer was not found: %s" % self.layer_name)
+            return False
+
+        # (3) Give edit permissions to each associated WorldMap user
+        #
+        for perm_link in perm_links:
+            # set to admin level.
+            # "set_user_level" clears perms before setting them.  It doesn't allow dupes
+            map_obj.set_user_level(perm_link.worldmap_user, Layer.LEVEL_ADMIN)
+
+        self.was_layer_linked = True
+        return True
+
+"""
+from geonode.contrib.dataverse_permission_links.permission_setter import PermissionLinker
+
+layer_name = 'geonode:starbucks_u_c2'
+dataverse_username = 'dv_bari'
+
+pl = PermissionLinker(layer_name, dataverse_username)
+if not pl.link_layer():
+    print pl.error_message
+else:
+    print 'worked!'
+
+"""

--- a/geonode/contrib/msg_util.py
+++ b/geonode/contrib/msg_util.py
@@ -5,8 +5,8 @@ from django.conf import settings
 
 
 def msg(s):
-    #if settings.DEBUG:
-    print(s)
+    if settings.DEBUG:
+        print(s)
 def dashes(d='-'): msg(40*d)
 def msgd(s): dashes(); msg(s)
 def msgt(s): dashes(); msg(s); dashes()

--- a/geonode/maps/utils.py
+++ b/geonode/maps/utils.py
@@ -235,20 +235,20 @@ def get_db_store_name(user=None):
     # https://osgeo-org.atlassian.net/browse/GEOS-7533
     # db_store_name = settings.DB_DATASTORE_NAME
     """
-    if settings.USE_MONTHLY_DATASTORE_FOR_TABULAR_MAPPING is False:
-        # Only one datastore, use it.
-        return settings.DB_DATASTORE_NAME
-
     # Is the user in the group "dataverse"?
     if user:
-        # only users in target-joins-uploader group will use the dataverse database
+        # only users in target-joins-uploader group will use the "dataverse" store
         if user.groups.filter(name=settings.DATAVERSE_GROUP_NAME).exists():
+            #print 'settings.DB_DATAVERSE_NAME', settings.DB_DATAVERSE_NAME
             return settings.DB_DATAVERSE_NAME
 
     # We're using a monthly db
     now = datetime.datetime.now()
     db_store_name = 'wm_%s%02d' % (now.year, now.month)
+
     return db_store_name
+
+
 
 
 def save(layer, base_file, user, overwrite = True, title=None,

--- a/geonode/maps/utils.py
+++ b/geonode/maps/utils.py
@@ -6,8 +6,6 @@ import logging
 from zipfile import ZipFile
 from random import choice
 import re
-from django.db import transaction
-from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from django.contrib.auth.models import User
 from geonode.maps.models import Map, Layer, MapLayer, Contact, ContactRole, Role, get_csw
@@ -27,7 +25,6 @@ from django.utils.translation import ugettext as _
 
 # Geonode functionality
 from geonode.maps.models import Contact, Layer, LayerAttribute
-from geonode.maps.gs_helpers import cascading_delete, get_sld_for, delete_from_postgis
 
 # Geoserver functionality
 import geoserver
@@ -229,15 +226,28 @@ def cleanup(name, layer_id):
 
 
 def get_db_store_name(user=None):
+    """
+    Used for tabular mapping.
+    In production, monthly dbs are created for new layers.
+    However: for joins, the tables must be in the same db
+
     # DB_DATASTORE_NAME is not used anymore now until this is fixed:
     # https://osgeo-org.atlassian.net/browse/GEOS-7533
     # db_store_name = settings.DB_DATASTORE_NAME
-    now = datetime.datetime.now()
-    db_store_name = 'wm_%s%02d' % (now.year, now.month)
+    """
+    if settings.USE_MONTHLY_DATASTORE_FOR_TABULAR_MAPPING is False:
+        # Only one datastore, use it.
+        return settings.DB_DATASTORE_NAME
+
+    # Is the user in the group "dataverse"?
     if user:
         # only users in target-joins-uploader group will use the dataverse database
         if user.groups.filter(name=settings.DATAVERSE_GROUP_NAME).exists():
-            db_store_name = settings.DB_DATAVERSE_NAME
+            return settings.DB_DATAVERSE_NAME
+
+    # We're using a monthly db
+    now = datetime.datetime.now()
+    db_store_name = 'wm_%s%02d' % (now.year, now.month)
     return db_store_name
 
 

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -8,7 +8,7 @@ gettext = lambda s: s
 #
 # General Django development settings
 #
-
+sys.path.append('/vagrant/shared-dataverse-information')
 
 ####################### DATAVERSE_INFO_REPOSITORY_PATH
 #
@@ -56,6 +56,13 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'wm_db',
+        'USER': 'wm_user',
+        'PASSWORD': 'wm_password',
+        'HOST': 'localhost', 'PORT': '5432'
+        },
+    'wmdata': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': 'wmdata',
         'USER': 'wm_user',
         'PASSWORD': 'wm_password',
         'HOST': 'localhost', 'PORT': '5432'
@@ -173,6 +180,7 @@ INSTALLED_APPS = (
     'shared_dataverse_information.layer_classification',     # external repository: https://github.com/IQSS/shared-dataverse-information
     'geonode.contrib.dataverse_layer_metadata', # uses the dataverse_info repository models
     'geonode.contrib.dataverse_connect',
+    'geonode.contrib.dataverse_permission_links',
 
 )
 LOGGING = {
@@ -502,11 +510,25 @@ GEONODE_CLIENT_LOCATION = "/static/geonode/"
 # GeoNode vector data backend configuration.
 
 #Import uploaded shapefiles into a database such as PostGIS?
-DB_DATASTORE = False
+DB_DATASTORE = True
 
 #
 #Database datastore connection settings
 #
+#
+USE_MONTHLY_DATASTORE_FOR_TABULAR_MAPPING = False
+
+DB_DATASTORE_DATABASE = 'wmdata'
+DB_DATASTORE_USER = 'wm_user'
+DB_DATASTORE_PASSWORD = 'wm_password'
+DB_DATASTORE_HOST = 'localhost'
+DB_DATASTORE_PORT = '5432'
+DB_DATASTORE_TYPE = 'postgis'
+# Name of the store in geoserver
+DB_DATASTORE_NAME = 'wmdata'   #wmdata'
+DB_DATASTORE_ENGINE = 'django.contrib.gis.db.backends.postgis'
+
+"""
 DB_DATASTORE_DATABASE = ''
 DB_DATASTORE_USER = ''
 DB_DATASTORE_PASSWORD = ''
@@ -516,6 +538,7 @@ DB_DATASTORE_TYPE = ''
 # Name of the store in geoserver
 DB_DATASTORE_NAME = ''
 DB_DATASTORE_ENGINE = 'django.contrib.gis.db.backends.postgis'
+"""
 
 """
 START GAZETTEER SETTINGS

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -8,7 +8,7 @@ gettext = lambda s: s
 #
 # General Django development settings
 #
-sys.path.append('/vagrant/shared-dataverse-information')
+
 
 ####################### DATAVERSE_INFO_REPOSITORY_PATH
 #
@@ -56,13 +56,6 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'wm_db',
-        'USER': 'wm_user',
-        'PASSWORD': 'wm_password',
-        'HOST': 'localhost', 'PORT': '5432'
-        },
-    'wmdata': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': 'wmdata',
         'USER': 'wm_user',
         'PASSWORD': 'wm_password',
         'HOST': 'localhost', 'PORT': '5432'
@@ -168,7 +161,6 @@ INSTALLED_APPS = (
     'geonode.capabilities',
     'geonode.queue',
     'geonode.certification',
-
     # Datatable API
     'geonode.contrib.datatables',
     #'geonode.hoods',
@@ -176,7 +168,7 @@ INSTALLED_APPS = (
     #'debug_toolbar',
     'geonode.actions',
 
-    #Dataverse apps
+    #DVN apps
     'shared_dataverse_information.dataverse_info',           # external repository: https://github.com/IQSS/shared-dataverse-information
     'shared_dataverse_information.layer_classification',     # external repository: https://github.com/IQSS/shared-dataverse-information
     'geonode.contrib.dataverse_permission_links',
@@ -511,25 +503,11 @@ GEONODE_CLIENT_LOCATION = "/static/geonode/"
 # GeoNode vector data backend configuration.
 
 #Import uploaded shapefiles into a database such as PostGIS?
-DB_DATASTORE = True
+DB_DATASTORE = False
 
 #
 #Database datastore connection settings
 #
-#
-USE_MONTHLY_DATASTORE_FOR_TABULAR_MAPPING = False
-
-DB_DATASTORE_DATABASE = 'wmdata'
-DB_DATASTORE_USER = 'wm_user'
-DB_DATASTORE_PASSWORD = 'wm_password'
-DB_DATASTORE_HOST = 'localhost'
-DB_DATASTORE_PORT = '5432'
-DB_DATASTORE_TYPE = 'postgis'
-# Name of the store in geoserver
-DB_DATASTORE_NAME = 'wmdata'   #wmdata'
-DB_DATASTORE_ENGINE = 'django.contrib.gis.db.backends.postgis'
-
-"""
 DB_DATASTORE_DATABASE = ''
 DB_DATASTORE_USER = ''
 DB_DATASTORE_PASSWORD = ''
@@ -539,7 +517,6 @@ DB_DATASTORE_TYPE = ''
 # Name of the store in geoserver
 DB_DATASTORE_NAME = ''
 DB_DATASTORE_ENGINE = 'django.contrib.gis.db.backends.postgis'
-"""
 
 """
 START GAZETTEER SETTINGS

--- a/geonode/settings.py
+++ b/geonode/settings.py
@@ -168,6 +168,7 @@ INSTALLED_APPS = (
     'geonode.capabilities',
     'geonode.queue',
     'geonode.certification',
+
     # Datatable API
     'geonode.contrib.datatables',
     #'geonode.hoods',
@@ -175,12 +176,12 @@ INSTALLED_APPS = (
     #'debug_toolbar',
     'geonode.actions',
 
-    #DVN apps
+    #Dataverse apps
     'shared_dataverse_information.dataverse_info',           # external repository: https://github.com/IQSS/shared-dataverse-information
     'shared_dataverse_information.layer_classification',     # external repository: https://github.com/IQSS/shared-dataverse-information
+    'geonode.contrib.dataverse_permission_links',
     'geonode.contrib.dataverse_layer_metadata', # uses the dataverse_info repository models
     'geonode.contrib.dataverse_connect',
-    'geonode.contrib.dataverse_permission_links',
 
 )
 LOGGING = {

--- a/shared/requirements.txt
+++ b/shared/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url=http://dist.pinaxproject.com/dev
 
-pip
+pip==1.0
 setuptools
 paver
 
@@ -67,7 +67,7 @@ django-tastypie==0.9.16
 # For the Dataverse/Geoconnect/WorldMap connection
 # --------------------------------------------------
 xmltodict
-shared_dataverse_information>=0.4.8
+shared_dataverse_information>=0.5.5
 #-e git+https://github.com/IQSS/shared-dataverse-information.git#egg=shared-dataverse-information
 
 # --------------------------------------------------


### PR DESCRIPTION
This request is a interim step to link Dataverse and WorldMap permissions for specific users as described in iqss/dataverse#3469.  Basically, specific users who:
  - (a) make a Layer via Dataverse and 
  - (b) possess WorldMap credentials  
  - (c) will have the ability to log into WorldMap and update the Dataverse-created layer
  - In general, all Dataverse-created layers are owned by a "service account" whose credentials are stored within Dataverse.  (The service account is a regular WorldMap/django account belonging to the django group "dataverse")

New files are in:
  -  geonode/contrib/dataverse_permission_links

This includes:
  - a new model: DataversePermissionLink to store which usernames should be linked 
  - simple PermissionLinker utility to link the permissions
  - **note**: The requirements file has an updated version number for pypi package ```shared_dataverse_information```

Most other changes are pylint/formatting related