### PR TITLE
Dataverse updates for 2 db columns

### DIFF
--- a/geonode/contrib/dataverse_layer_metadata/admin.py
+++ b/geonode/contrib/dataverse_layer_metadata/admin.py
@@ -6,10 +6,26 @@ from geonode.contrib.dataverse_layer_metadata.forms import DataverseLayerMetadat
 class DataverseLayerMetadataAdmin(admin.ModelAdmin):
     form = DataverseLayerMetadataAdminForm
     save_on_top = True
-    search_fields = ('map_layer__name',  'dataverse_name', 'dataset_name', 'datafile_label', 'dataset_description')
-    list_display = ('map_layer', 'dataset_name', 'datafile_id', 'datafile_label', 'dataverse_name', 'modified',  'created')
-    list_filter = ('dataset_is_public', 'dataverse_name', )
-    readonly_fields = ('modified', 'created', 'dataset_is_public', 'datafile_create_datetime', 'datafile_expected_md5_checksum' )
+    search_fields = ('map_layer__name',
+                     'dataverse_name',
+                     'dataset_name',
+                     'datafile_label',
+                     'dataset_description')
+    list_display = ('map_layer',
+                    'dataset_name',
+                    'datafile_id',
+                    'datafile_label',
+                    'dataverse_name',
+                    'modified',
+                    'created')
+    list_filter = ('dataset_is_public',
+                   'dataverse_name', )
+    readonly_fields = ('modified',
+                       'created',
+                       'dataset_is_public',
+                       'datafile_is_restricted',
+                       'datafile_create_datetime',
+                       'datafile_expected_md5_checksum' )
     fieldsets = (
            (None, {
                'fields': ('map_layer',)
@@ -18,18 +34,28 @@ class DataverseLayerMetadataAdmin(admin.ModelAdmin):
                     'fields': (('dv_user_id', 'dv_username', 'dv_user_email'),)
                 }),
            ('Dataverse', {
-               'fields': ('dataverse_installation_name', ('dataverse_name', 'dataverse_id'), 'dataverse_description')
+               'fields': ('dataverse_installation_name',
+                          ('dataverse_name', 'dataverse_id'),
+                          'dataverse_description')
            }),
             ('Dataset/Dataset Version', {
-                  'fields': (('dataset_name', 'dataset_citation')\
-                        , 'dataset_is_public'\
-                        , ('dataset_semantic_version', 'dataset_id', 'dataset_version_id')\
-                        , 'dataset_description')
+                  'fields': ('dataset_name',
+                             'dataset_citation',
+                             'dataset_is_public',
+                             ('dataset_semantic_version',
+                              'dataset_id',
+                              'dataset_version_id'),
+                             'dataset_description')
               }),
               ('Datafile Information', {
-                    'fields': (('datafile_label', 'datafile_id')\
-                          , ('datafile_filesize', 'datafile_content_type', 'datafile_expected_md5_checksum')\
-                          , 'datafile_create_datetime')
+                    'fields': (\
+                        ('datafile_label',
+                         'datafile_id',
+                         'datafile_is_restricted'),
+                         ('datafile_filesize',
+                          'datafile_content_type',
+                          'datafile_expected_md5_checksum'),
+                         'datafile_create_datetime')
                 }),
                  ('Dataverse Urls', {
                         'fields': (('return_to_dataverse_url', 'datafile_download_url',),)

--- a/shared/requirements.txt
+++ b/shared/requirements.txt
@@ -67,7 +67,7 @@ django-tastypie==0.9.16
 # For the Dataverse/Geoconnect/WorldMap connection
 # --------------------------------------------------
 xmltodict
-shared_dataverse_information>=0.5.5
+shared_dataverse_information>=0.5.7
 #-e git+https://github.com/IQSS/shared-dataverse-information.git#egg=shared-dataverse-information
 
 # --------------------------------------------------


### PR DESCRIPTION
- **(!)Note: In addition to code, this pull request will require 2 manual updates detailed below**

- This is for iqss/dataverse#3432 -- when dataset citations are over 255 chars in length

## change 1: Pip requirements change

- This PR updates the pip version for the package ```shared_dataverse_information```
- This update may be run manually:

```
pip install shared_dataverse_information>=0.5.7
```

## change 2: Postgres column updates

The updated ```shared_dataverse_information```:
  - (a) alters a Django model attribute and
  - (b)  adds an attribute.

The following SQL corresponds to these attribute changes.  (This a dataverse specific table.)

Manual postgres updates for worldmap

```sql
    BEGIN;
        ALTER TABLE dataverse_layer_metadata_dataverselayermetadata
            ALTER COLUMN dataset_citation TYPE TEXT;
        ALTER TABLE dataverse_layer_metadata_dataverselayermetadata
            ADD COLUMN datafile_is_restricted BOOLEAN DEFAULT FALSE;
    COMMIT;
```



