### PR TITLE
Minor tweaks to datatables admin and word change to error message. iq…

### DIFF
--- a/geonode/contrib/datatables/admin.py
+++ b/geonode/contrib/datatables/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django import forms
 from geonode.maps.models import Layer, LayerAttribute
 from .models import DataTable, DataTableAttribute, TableJoin, JoinTarget, JoinTargetFormatType, GeocodeType, LatLngTableMappingRecord
+from .admin_forms import JoinTargetAdminForm, TableJoinAdminForm
 import string
 
 class DataTableAdmin(admin.ModelAdmin):
@@ -19,65 +20,56 @@ class DataTableAdmin(admin.ModelAdmin):
 
 
 class DataTableAttributeAdmin(admin.ModelAdmin):
-    list_display = ('attribute', 'attribute_label', 'datatable', 'attribute_type', 'searchable')
-    list_filter  = ('datatable', 'searchable', 'attribute_type')
+    list_display = ('attribute',
+                    'attribute_label',
+                    'datatable',
+                    'attribute_type',
+                    'searchable')
+
+    list_filter  = ('datatable',
+                    'searchable',
+                    'attribute_type')
 
 class LatLngTableMappingRecordAdmin(admin.ModelAdmin):
     search_fields = ('title',)
-    list_display = ('datatable', 'lat_attribute', 'lng_attribute', 'layer', 'mapped_record_count', 'unmapped_record_count', 'created')
+    list_display = ('datatable',
+                    'lat_attribute',
+                    'lng_attribute',
+                    'layer',
+                    'mapped_record_count',
+                    'unmapped_record_count',
+                    'created')
     list_filter  = ('datatable',)# 'layer', )
 
 
 
 class TableJoinAdmin(admin.ModelAdmin):
     model = TableJoin
+    form = TableJoinAdminForm
+    list_display = ('id', 'join_layer',
+                    'datatable', 'table_attribute',
+                    'source_layer', 'layer_attribute',
+                    'created', 'modified')
 
-
-class JoinTargetAdminForm(forms.ModelForm):
-    """
-    Limit the JoinTarget Layer and LayerAttribute choices.
-    (If not limited, the page can take many minutes--or never load
-        e.g. listing 20k+ layers and all of the attributes in those layers
-    )
-    """
-    def __init__(self, *args, **kwargs):
-        super(JoinTargetAdminForm, self).__init__(*args, **kwargs)
-
-        selected_layer_id = kwargs.get('initial', {}).get('layer', None)
-
-        # Is this an existing/saved Join Target?
-        #
-        if self.instance and self.instance.id:
-            # Yes, limit choices to the chosen layer and its attributes
-            #
-            self.fields['layer'].queryset = Layer.objects.filter(\
-                                    pk=self.instance.layer.id)
-            self.fields['attribute'].queryset = LayerAttribute.objects.filter(\
-                                    layer=self.instance.layer.id)
-
-        elif selected_layer_id and selected_layer_id.isdigit():
-            self.fields['layer'].queryset = Layer.objects.filter(\
-                                            pk=selected_layer_id)
-            self.fields['attribute'].queryset = LayerAttribute.objects.filter(\
-                                            layer=selected_layer_id)
-
-
-        elif 'initial' in kwargs:
-            # We can't "afford" to list everything.
-            # Don't list any layers or their attributes
-            #   - An admin template instructs the user on how
-            #       to add a new JoinTarget via the Layer admin
-            #
-            self.fields['layer'].queryset = Layer.objects.none()
-            self.fields['attribute'].queryset = LayerAttribute.objects.none()
-
+    search_fields = ('source_layer__name',
+                     'datatable__title',
+                     'datatable__table_name',
+                     'join_layer__name')
 
 
 class JoinTargetAdmin(admin.ModelAdmin):
     model = JoinTarget
     form = JoinTargetAdminForm
-    list_display = ('name', 'layer', 'attribute', 'geocode_type', 'expected_format', 'year')
+    list_display = ('name',
+                    'layer',
+                    'attribute',
+                    'geocode_type',
+                    'expected_format',
+                    'year')
+
     readonly_fields = ('return_to_layer_admin', )
+
+    search_fields = ('name', 'layer__name')
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == 'attribute':

--- a/geonode/contrib/datatables/admin_forms.py
+++ b/geonode/contrib/datatables/admin_forms.py
@@ -1,0 +1,82 @@
+from django import forms
+from geonode.maps.models import Layer, LayerAttribute
+from geonode.contrib.datatables.models import DataTable, DataTableAttribute
+
+class TableJoinAdminForm(forms.ModelForm):
+    """
+    Limit the layer and attribute choices.
+    """
+    def __init__(self, *args, **kwargs):
+        super(TableJoinAdminForm, self).__init__(*args, **kwargs)
+
+        if self.instance and self.instance.id:
+            # Yes, limit choices
+
+            # Set the datatable and attribute
+            self.fields['datatable'].queryset = DataTable.objects.filter(\
+                                    pk=self.instance.datatable.id)
+
+            self.fields['table_attribute'].queryset = DataTableAttribute.objects.filter(\
+                                    datatable=self.instance.datatable.id)
+
+            # Set the source layer and attribute
+            self.fields['source_layer'].queryset = Layer.objects.filter(\
+                                    pk=self.instance.source_layer.id)
+
+            self.fields['layer_attribute'].queryset = LayerAttribute.objects.filter(\
+                                    layer=self.instance.source_layer.id)
+
+            # Set the Join layer
+            self.fields['join_layer'].queryset = Layer.objects.filter(\
+                                    pk=self.instance.join_layer.id)
+
+        elif 'initial' in kwargs:
+            # These objects can't be created through the admin
+            # Also, production would create dropdowns with 1000s of listings
+            #
+            self.fields['datatable'].queryset = DataTable.objects.none()
+            self.fields['table_attribute'].queryset = DataTableAttribute.objects.none()
+
+            self.fields['source_layer'].queryset = Layer.objects.none()
+            self.fields['layer_attribute'].queryset = LayerAttribute.objects.none()
+
+            self.fields['join_layer'].queryset = Layer.objects.none()
+
+
+class JoinTargetAdminForm(forms.ModelForm):
+    """
+    Limit the JoinTarget Layer and LayerAttribute choices.
+    (If not limited, the page can take many minutes--or never load
+        e.g. listing 20k+ layers and all of the attributes in those layers
+    )
+    """
+    def __init__(self, *args, **kwargs):
+        super(JoinTargetAdminForm, self).__init__(*args, **kwargs)
+
+        selected_layer_id = kwargs.get('initial', {}).get('layer', None)
+
+        # Is this an existing/saved Join Target?
+        #
+        if self.instance and self.instance.id:
+            # Yes, limit choices to the chosen layer and its attributes
+            #
+            self.fields['layer'].queryset = Layer.objects.filter(\
+                                    pk=self.instance.layer.id)
+            self.fields['attribute'].queryset = LayerAttribute.objects.filter(\
+                                    layer=self.instance.layer.id)
+
+        elif selected_layer_id and selected_layer_id.isdigit():
+            self.fields['layer'].queryset = Layer.objects.filter(\
+                                            pk=selected_layer_id)
+            self.fields['attribute'].queryset = LayerAttribute.objects.filter(\
+                                            layer=selected_layer_id)
+
+
+        elif 'initial' in kwargs:
+            # We can't "afford" to list everything.
+            # Don't list any layers or their attributes
+            #   - An admin template instructs the user on how
+            #       to add a new JoinTarget via the Layer admin
+            #
+            self.fields['layer'].queryset = Layer.objects.none()
+            self.fields['attribute'].queryset = LayerAttribute.objects.none()

--- a/geonode/contrib/datatables/utils_lat_lng.py
+++ b/geonode/contrib/datatables/utils_lat_lng.py
@@ -51,7 +51,7 @@ def is_valid_lat_lng_attribute(dt_attr, lng_check=False):
     if lng_check:
         col_type = 'longitude'
 
-    err_msg = 'Not a valid %s column. Column "%s" is type "%s".   All data in the column must be a float or double.' \
+    err_msg = 'Not a valid %s column. Column "%s" is type "%s".   All data in the column must be numeric.' \
                                     % (col_type, dt_attr.attribute, dt_attr.attribute_type)
     return False, err_msg
 


### PR DESCRIPTION
Part of iqss/dataverse#3481

---

This  PR has minor tweaks to the django admin for datatables, mainly limiting the choices for TableJoin attributes.  e.g. We don't want two dropdowns listing all layers in the system, etc.

